### PR TITLE
env.mk: ensure mkdir -p is called before installing libs

### DIFF
--- a/env.mk
+++ b/env.mk
@@ -124,6 +124,7 @@ endef
 define macro-sh-generate-install-lib-rule
 $(INSTALL_ROOT)/$(SH_ARCH)/$(SH_ARCH)/lib/$2: $1
 	@printf -- "$(V_BEGIN_BLUE)lib/$2$(V_END)\n"
+	mkdir -p "$$(@D)"
 	$(ECHO)$(INSTALL) -m 644 $$< $$@
 
 install-$3: $3 $(INSTALL_ROOT)/$(SH_ARCH)/$(SH_ARCH)/lib/$2


### PR DESCRIPTION
I ran into this when installing libyaul into a different location than the toolchain. The lib paths will already exist when installing into the toolchain's prefix, but probably won't when installing anywhere else. There's an equivalent `mkdir -p` for the headers, so I figured this was worth it for consistency.