### PR TITLE
build-compiler: use -q flag for BSD md5

### DIFF
--- a/build-scripts/build-compiler
+++ b/build-scripts/build-compiler
@@ -167,7 +167,7 @@ function checksum_md5() {
     _md5=`cat "${_file}" 2> /dev/null | grep "${_archive}" 2> /dev/null | sed 's/[[:space:]][[:space:]]*/,/g' | cut -d ',' -f 1`
     case "${MD5}" in
         "md5")
-            _calculated_md5=`"${MD5}" "${_archive}" | awk '{ print $1; }'`
+            _calculated_md5=`"${MD5}" -q "${_archive}"
             ;;
         "md5sum")
             _calculated_md5=`"${MD5}" "${_archive}" | sed -r -n 's/^([a-f0-9][a-f0-9]*)\s+.*?$/\1/pg'`


### PR DESCRIPTION
This fixes a bug where MD5s were being calculated wrong on BSD md5. The first part of the output from BSD md5 is the text `MD5` rather than the hash itself, so the hash was being compared against the wrong string.

Rather than parsing out the md5, it's easiest just to use the quiet option to return only the hash. That avoids a call to awk entirely. I've checked and it looks like this should be reasonably compatible; FreeBSD md5 has had this option since [1999](https://github.com/freebsd/freebsd/commit/b6b57faeef807ca8b13a23e047d8479ab962044b), and OpenBSD has had it since [2006](https://github.com/openbsd/src/commit/de516bc06c62ad892b1c68783d3c451607e2f5c9).