### PR TITLE
build-scripts: adjust LDFLAGS for other platforms

### DIFF
--- a/build-scripts/build-compiler
+++ b/build-scripts/build-compiler
@@ -638,6 +638,8 @@ cd - 1> /dev/null
 
 message "Building targets: `echo ${TARGETS[@]} | sed -E 's/ /, /g'`"
 
+export HOST_OS="$(uname -s)"
+
 for target in ${TARGETS[@]}; do
     if [ -f "${BUILD_STAMPS_DIR}/${target}-completed-build" ]; then
         continue

--- a/build-scripts/m68k-elf/scripts/build
+++ b/build-scripts/m68k-elf/scripts/build
@@ -11,6 +11,19 @@
 
 is_var_set "target"
 
+extra_ldflags=""
+# Darwin does not support the -static flag, because its libc
+# is not shipped as a static library.
+if [ "${HOST_OS}" != "Darwin" ]; then
+    extra_ldflags="-static"
+fi
+
+# -static-libgcc is only relevant for GCC
+compiler_version="$(${CC-gcc} --version 2>&1)"
+if ! echo "${compiler_version}" | grep -E -q "(clang|Apple LLVM) version"; then
+    extra_ldflags="${extra_ldflags} -static-libgcc"
+fi
+
 # Build and install Binutils
 mkdir -p "${BUILD_SRC_DIR}/${target}/binutils"
 cd "${BUILD_SRC_DIR}/${target}/binutils"
@@ -34,7 +47,7 @@ fi
 if ! [ -f "${BUILD_STAMPS_DIR}/${target}-configured-binutils" ]; then
     message "Configuring Binutils"
     CFLAGS="" \
-    LDFLAGS="-static -static-libgcc -static-libstdc++" ../"${BINUTILS_SRC_DIR}"/configure \
+    LDFLAGS="$extra_ldflags -static-libstdc++" ../"${BINUTILS_SRC_DIR}"/configure \
         ${binutils_configure_options[@]} 1>> "${BUILD_SRC_DIR}/binutils-${target}.log" 2>&1 \
         || panic "See '${BUILD_SRC_DIR}/binutils-${target}.log'" 1
     create_stamp "${target}-configured-binutils"

--- a/build-scripts/sh-elf/scripts/build
+++ b/build-scripts/sh-elf/scripts/build
@@ -10,6 +10,19 @@
 
 is_var_set "target"
 
+extra_ldflags=""
+# Darwin does not support the -static flag, because its libc
+# is not shipped as a static library.
+if [ "${HOST_OS}" != "Darwin" ]; then
+    extra_ldflags="-static"
+fi
+
+# -static-libgcc is only relevant for GCC
+compiler_version="$(${CC-gcc} --version 2>&1)"
+if ! echo "${compiler_version}" | grep -E -q "(clang|Apple LLVM) version"; then
+    extra_ldflags="${extra_ldflags} -static-libgcc"
+fi
+
 # Build and install Binutils
 mkdir -p "${BUILD_SRC_DIR}/${target}/binutils"
 cd "${BUILD_SRC_DIR}/${target}/binutils"
@@ -33,7 +46,7 @@ fi
 if ! [ -f "${BUILD_STAMPS_DIR}/${target}-configured-binutils" ]; then
     message "Configuring Binutils"
     CFLAGS="" \
-    LDFLAGS="-static -static-libgcc -static-libstdc++" ../"${BINUTILS_SRC_DIR}"/configure \
+    LDFLAGS="$extra_ldflags -static-libstdc++" ../"${BINUTILS_SRC_DIR}"/configure \
         ${binutils_configure_options[@]} 1>> "${BUILD_SRC_DIR}/binutils-${target}.log" 2>&1 \
         || panic "See '${BUILD_SRC_DIR}/binutils-${target}.log'" 1
     create_stamp "${target}-configured-binutils"
@@ -108,7 +121,7 @@ fi
 if ! [ -f "${BUILD_STAMPS_DIR}/${target}-configured-gcc" ]; then
     message "Configuring GCC"
     CFLAGS="" \
-    LDFLAGS="-static -static-libgcc -static-libstdc++" \
+    LDFLAGS="$extra_ldflags -static-libstdc++" \
     CFLAGS_FOR_TARGET="-O2 -m2 -mb -fomit-frame-pointer -ffreestanding" \
     LDFLAGS_FOR_TARGET="" ../"${GCC_SRC_DIR}"/configure \
         ${gcc_configure_options[@]} 1>> "${BUILD_SRC_DIR}/gcc-${target}.log" 2>&1 \


### PR DESCRIPTION
This fixes a couple of build failures I encountered when building on OS X.

* `-static` doesn't work on Darwin, which doesn't provide a static version of its libc. Without `-static`, you still end up with a build that's only linked against the system libraries, so it's still distributable.
* `-static-libgcc` only works for GCC, and raises an error on clang.

Sorry about the ugly clang check; I couldn't get bash's `=~` to be happy with that expression so I switched to `egrep`.