### PR TITLE
Fix C++ linking and compilation problems

### DIFF
--- a/libyaul/scu/bus/b/vdp/vdp1.h
+++ b/libyaul/scu/bus/b/vdp/vdp1.h
@@ -29,22 +29,22 @@ struct vdp1_transfer_status {
         };
 } __packed __aligned(2);
 
-        struct vdp1_mode_status {
-                union {
-                        struct {
-                                unsigned vms_version:4;
-                                unsigned :3;
-                                unsigned vms_ptm1:1;
-                                unsigned vms_eos:1;
-                                unsigned vms_die:1;
-                                unsigned vms_dil:1;
-                                unsigned vms_fcm:1;
-                                unsigned vms_vbe:1;
-                                unsigned vms_tvm:3;
-                        } __packed;
+struct vdp1_mode_status {
+        union {
+                struct {
+                        unsigned vms_version:4;
+                        unsigned :3;
+                        unsigned vms_ptm1:1;
+                        unsigned vms_eos:1;
+                        unsigned vms_die:1;
+                        unsigned vms_dil:1;
+                        unsigned vms_fcm:1;
+                        unsigned vms_vbe:1;
+                        unsigned vms_tvm:3;
+                } __packed;
 
-                        uint16_t raw;
-                };
+                uint16_t raw;
+        };
 } __packed __aligned(2);
 
 static inline void __attribute__ ((always_inline))
@@ -52,7 +52,7 @@ vdp1_mode_status_get(struct vdp1_mode_status *status)
 {
         /* If the structure isn't aligned on a 2-byte boundary, GCC will
          * attempt to invoke memcpy() */
-        *status = *(struct vdp1_mode_status *)VDP1(MODR);
+        status->raw = MEMORY_READ(16, VDP1(MODR));
 }
 
 static inline void __attribute__ ((always_inline))
@@ -60,7 +60,7 @@ vdp1_transfer_status_get(struct vdp1_transfer_status *status)
 {
         /* If the structure isn't aligned on a 2-byte boundary, GCC will
          * attempt to invoke memcpy() */
-        *status = *(struct vdp1_transfer_status *)VDP1(EDSR);
+        status->raw = MEMORY_READ(16, VDP1(EDSR));
 }
 
 #ifdef __cplusplus

--- a/libyaul/scu/bus/b/vdp/vdp1.h
+++ b/libyaul/scu/bus/b/vdp/vdp1.h
@@ -52,7 +52,7 @@ vdp1_mode_status_get(struct vdp1_mode_status *status)
 {
         /* If the structure isn't aligned on a 2-byte boundary, GCC will
          * attempt to invoke memcpy() */
-        *status = *(volatile struct vdp1_mode_status *)VDP1(MODR);
+        *status = *(struct vdp1_mode_status *)VDP1(MODR);
 }
 
 static inline void __attribute__ ((always_inline))
@@ -60,7 +60,7 @@ vdp1_transfer_status_get(struct vdp1_transfer_status *status)
 {
         /* If the structure isn't aligned on a 2-byte boundary, GCC will
          * attempt to invoke memcpy() */
-        *status = *(volatile struct vdp1_transfer_status *)VDP1(EDSR);
+        *status = *(struct vdp1_transfer_status *)VDP1(EDSR);
 }
 
 #ifdef __cplusplus

--- a/libyaul/scu/bus/cpu/cpu.h
+++ b/libyaul/scu/bus/cpu/cpu.h
@@ -25,6 +25,12 @@ extern "C" {
 #endif /* __cplusplus */
 
 extern void cpu_init(void);
+extern void _slave_polling_entry(void);
+extern void _slave_ici_entry(void);
+extern void _exception_illegal_instruction(void);
+extern void _exception_illegal_slot(void);
+extern void _exception_cpu_address_error(void);
+extern void _exception_dma_address_error(void);
 
 #ifdef __cplusplus
 }

--- a/libyaul/scu/bus/cpu/cpu.h
+++ b/libyaul/scu/bus/cpu/cpu.h
@@ -25,12 +25,6 @@ extern "C" {
 #endif /* __cplusplus */
 
 extern void cpu_init(void);
-extern void _slave_polling_entry(void);
-extern void _slave_ici_entry(void);
-extern void _exception_illegal_instruction(void);
-extern void _exception_illegal_slot(void);
-extern void _exception_cpu_address_error(void);
-extern void _exception_dma_address_error(void);
 
 #ifdef __cplusplus
 }

--- a/libyaul/scu/bus/cpu/cpu_dual.c
+++ b/libyaul/scu/bus/cpu/cpu_dual.c
@@ -130,7 +130,7 @@ _slave_init(void)
 
 SLAVE_ENTRY_TRAMPOLINE_EMIT(polling);
 
-static void __noreturn __aligned(16)
+static void __noreturn __aligned(16) __used 
 _slave_polling_entry(void)
 {
         _slave_init();
@@ -144,7 +144,7 @@ _slave_polling_entry(void)
 
 SLAVE_ENTRY_TRAMPOLINE_EMIT(ici);
 
-static void __noreturn
+static void __noreturn __used 
 _slave_ici_entry(void)
 {
         _slave_init();

--- a/libyaul/scu/bus/cpu/cpu_init.c
+++ b/libyaul/scu/bus/cpu/cpu_init.c
@@ -99,7 +99,7 @@ cpu_init(void)
         cpu_dual_init(CPU_DUAL_ENTRY_POLLING);
 }
 
-static void __noreturn
+static void __noreturn __used 
 _ihr_exception_illegal_instruction(struct cpu_registers *regs)
 {
         _format_exception_message(regs, _buffer, "Illegal instruction");
@@ -107,7 +107,7 @@ _ihr_exception_illegal_instruction(struct cpu_registers *regs)
         _internal_exception_show(_buffer);
 }
 
-static void __noreturn
+static void __noreturn __used 
 _ihr_exception_illegal_slot(struct cpu_registers *regs)
 {
         _format_exception_message(regs, _buffer, "Illegal slot");
@@ -115,7 +115,7 @@ _ihr_exception_illegal_slot(struct cpu_registers *regs)
         _internal_exception_show(_buffer);
 }
 
-static void __noreturn
+static void __noreturn __used 
 _ihr_exception_cpu_address_error(struct cpu_registers *regs)
 {
         _format_exception_message(regs, _buffer, "CPU address error");
@@ -123,7 +123,7 @@ _ihr_exception_cpu_address_error(struct cpu_registers *regs)
         _internal_exception_show(_buffer);
 }
 
-static void __noreturn
+static void __noreturn __used 
 _ihr_exception_dma_address_error(struct cpu_registers *regs)
 {
         _format_exception_message(regs, _buffer, "DMA address error");


### PR DESCRIPTION
Fix linking errors due to functions being optimized and not exported on C++ and also an error related to pointer cast to volatile (and the parameter being a non-volatile pointer).