### PR TITLE
Bootable cart support

### DIFF
--- a/libyaul/common/bootstrap/ip.sx
+++ b/libyaul/common/bootstrap/ip.sx
@@ -52,4 +52,4 @@
 .LC1:
 .long .LC0
 
-.fill 244
+.fill 256 ! Making IP.BIN bigger than 4K according to CD spec.

--- a/libyaul/common/bootstrap/ip.sx
+++ b/libyaul/common/bootstrap/ip.sx
@@ -51,3 +51,5 @@
 
 .LC1:
 .long .LC0
+
+.fill 244

--- a/libyaul/common/post.common.mk
+++ b/libyaul/common/post.common.mk
@@ -210,8 +210,12 @@ $(SH_PROGRAM).iso: $(SH_PROGRAM).bin IP.BIN $(shell find $(IMAGE_DIRECTORY)/ -ty
 
 $(SH_PROGRAM).ss: $(SH_PROGRAM).bin IP.BIN
 	@printf -- "$(V_BEGIN_YELLOW)$@$(V_END)\n"
-	$(ECHO)cp IP.BIN $@
-	$(ECHO)cat $(SH_PROGRAM).bin >> $@
+	$$(if ! [ $$(($(IP_1ST_READ_SIZE))) -eq 0 ]; then \
+			$(ECHO)cp IP.BIN $@ ;\
+			$(ECHO)cat $(SH_PROGRAM).bin >> $@ ;\
+		else \
+			$(ECHO)touch $@ ;\
+		fi )
 
 $(SH_PROGRAM).cue: $(SH_PROGRAM).iso $(SH_PROGRAM).ss
 	@printf -- "$(V_BEGIN_YELLOW)$@$(V_END)\n"
@@ -247,6 +251,7 @@ clean:
 	    $(SH_PROGRAM).bin \
 	    $(SH_PROGRAM).cue \
 	    $(SH_PROGRAM).iso \
+	    $(SH_PROGRAM).ss \
 	    $(SH_OBJECTS_UNIQ) \
 	    $(SH_DEPS) \
 	    $(SH_DEPS_NO_LINK) \

--- a/libyaul/common/post.common.mk
+++ b/libyaul/common/post.common.mk
@@ -211,7 +211,6 @@ $(SH_PROGRAM).iso: $(SH_PROGRAM).bin IP.BIN $(shell find $(IMAGE_DIRECTORY)/ -ty
 $(SH_PROGRAM).ss: $(SH_PROGRAM).bin IP.BIN
 	@printf -- "$(V_BEGIN_YELLOW)$@$(V_END)\n"
 	$(ECHO)cp IP.BIN $@
-	$(ECHO)truncate $@ -s 4096
 	$(ECHO)cat $(SH_PROGRAM).bin >> $@
 
 $(SH_PROGRAM).cue: $(SH_PROGRAM).iso $(SH_PROGRAM).ss
@@ -231,15 +230,16 @@ IP.BIN: $(YAUL_INSTALL_ROOT)/share/yaul/bootstrap/ip.sx $(SH_PROGRAM).bin
 		$(IP_1ST_READ_ADDR) \
 		$$(if [ $$(($(IP_1ST_READ_SIZE))) -eq 0 ]; then \
 			printf 0x00000000; \
-			else if  [ $$(($(IP_1ST_READ_SIZE))) -eq -1 ]; then \
-				if  [ $$(stat -c "%s" $(SH_PROGRAM).bin) -lt $$((0x20000)) ]; then \
-				printf 0x00020000; \
-				else printf $$(stat -c "%s" $(SH_PROGRAM).bin); \
-				fi \
-			else \
-				printf $$(($(IP_1ST_READ_SIZE))); \
-			fi \
-			fi )
+            else if  [ $$(($(IP_1ST_READ_SIZE))) -eq -1 ]; then \
+                if  [ $$(stat -c "%s" $(SH_PROGRAM).bin) -lt $$((0x20000)) ]; then \
+                    printf 0x00020000; \
+                else \
+                    printf $$(stat -c "%s" $(SH_PROGRAM).bin); \
+                fi \
+            else \
+                printf $$(($(IP_1ST_READ_SIZE))); \
+            fi \
+        fi )
 
 clean:
 	$(ECHO)printf -- "$(V_BEGIN_CYAN)$(SH_PROGRAM)$(V_END) $(V_BEGIN_GREEN)clean$(V_END)\n"

--- a/libyaul/common/post.common.mk
+++ b/libyaul/common/post.common.mk
@@ -218,8 +218,9 @@ $(SH_PROGRAM).cue: $(SH_PROGRAM).iso $(SH_PROGRAM).ss
 	@printf -- "$(V_BEGIN_YELLOW)$@$(V_END)\n"
 	$(ECHO)$(YAUL_INSTALL_ROOT)/bin/make-cue "$(SH_PROGRAM).iso" $(MAKE_ISO_REDIRECT)
 
-IP.BIN: $(YAUL_INSTALL_ROOT)/share/yaul/bootstrap/ip.sx
-	$(ECHO)$(YAUL_INSTALL_ROOT)/bin/make-ip	\
+IP.BIN: $(YAUL_INSTALL_ROOT)/share/yaul/bootstrap/ip.sx $(SH_PROGRAM).bin
+	@printf -- "$(V_BEGIN_YELLOW)$@$(V_END)\n"
+	$(YAUL_INSTALL_ROOT)/bin/make-ip	\
 		"$(IP_VERSION)" \
 		$(IP_RELEASE_DATE) \
 		"$(IP_AREAS)" \
@@ -228,7 +229,17 @@ IP.BIN: $(YAUL_INSTALL_ROOT)/share/yaul/bootstrap/ip.sx
 		$(IP_MASTER_STACK_ADDR) \
 		$(IP_SLAVE_STACK_ADDR) \
 		$(IP_1ST_READ_ADDR) \
-		$(IP_1ST_READ_SIZE)
+		$$(if [ $$(($(IP_1ST_READ_SIZE))) -eq 0 ]; then \
+			printf 0x00000000; \
+			else if  [ $$(($(IP_1ST_READ_SIZE))) -eq -1 ]; then \
+				if  [ $$(stat -c "%s" $(SH_PROGRAM).bin) -lt $$((0x20000)) ]; then \
+				printf 0x00020000; \
+				else printf $$(stat -c "%s" $(SH_PROGRAM).bin); \
+				fi \
+			else \
+				printf $$(($(IP_1ST_READ_SIZE))); \
+			fi \
+			fi )
 
 clean:
 	$(ECHO)printf -- "$(V_BEGIN_CYAN)$(SH_PROGRAM)$(V_END) $(V_BEGIN_GREEN)clean$(V_END)\n"

--- a/libyaul/common/post.common.mk
+++ b/libyaul/common/post.common.mk
@@ -208,7 +208,13 @@ $(SH_PROGRAM).iso: $(SH_PROGRAM).bin IP.BIN $(shell find $(IMAGE_DIRECTORY)/ -ty
 	done
 	$(ECHO)$(YAUL_INSTALL_ROOT)/bin/make-iso $(IMAGE_DIRECTORY) $(SH_PROGRAM) $(MAKE_ISO_REDIRECT)
 
-$(SH_PROGRAM).cue: $(SH_PROGRAM).iso
+$(SH_PROGRAM).ss: $(SH_PROGRAM).bin IP.BIN
+	@printf -- "$(V_BEGIN_YELLOW)$@$(V_END)\n"
+	$(ECHO)cp IP.BIN $@
+	$(ECHO)truncate $@ -s 4096
+	$(ECHO)cat $(SH_PROGRAM).bin >> $@
+
+$(SH_PROGRAM).cue: $(SH_PROGRAM).iso $(SH_PROGRAM).ss
 	@printf -- "$(V_BEGIN_YELLOW)$@$(V_END)\n"
 	$(ECHO)$(YAUL_INSTALL_ROOT)/bin/make-cue "$(SH_PROGRAM).iso" $(MAKE_ISO_REDIRECT)
 


### PR DESCRIPTION
Cart image is generated with .ss extension. By default the file is zero-sized, because the IP_1ST_READ_SIZE is not provided in makefile, it defaults to 0, and the cart is not bootable with zero size. To make it work, IP_1ST_READ_SIZE in makefile needs to be set to either -1 (auto size) or a non-zero size. Sizes less than 0x20000 (both auto and manual) are extended to 0x20000, because the cart is unbootable with less sizes.
Cart can be launched in mednafen by providing a *.ss file name as a command line argument. For yabause forks, one need to set the cart type in settings to 16Mbit ROM, provide the *.ss file, and reboot the emulator.