### PR TITLE
Fix fix16_mat3_t alignment to 4 bytes instead of 64

### DIFF
--- a/libyaul/math/fix16_mat3.h
+++ b/libyaul/math/fix16_mat3.h
@@ -25,7 +25,7 @@ typedef union fix16_mat3 {
         fix16_t arr[9];
         fix16_t frow[3][3];
         fix16_vec3_t row[3];
-} __aligned(64) fix16_mat3_t;
+} __aligned(4) fix16_mat3_t;
 
 extern void fix16_mat3_dup(const fix16_mat3_t *, fix16_mat3_t *);
 extern void fix16_mat3_identity(fix16_mat3_t *);


### PR DESCRIPTION
fix16_mat3_t being aligned to 64 bytes is just wasteful, revert that to 4 bytes.