### PR TITLE
Improvements/cd block transfer

### DIFF
--- a/libyaul/kernel/vfs/fs/iso9660/iso9660.c
+++ b/libyaul/kernel/vfs/fs/iso9660/iso9660.c
@@ -252,7 +252,7 @@ _filelist_entry_populate(const iso9660_dirent_t *dirent, iso9660_entry_type_t ty
                 name_len -= 2;
 
                 /* Empty extension */
-                if (dirent->name[name_len - 1] == '.')
+                if (name_len > 0 && dirent->name[name_len - 1] == '.')
                         name_len--;
         }
 

--- a/libyaul/kernel/vfs/fs/iso9660/iso9660.c
+++ b/libyaul/kernel/vfs/fs/iso9660/iso9660.c
@@ -252,8 +252,9 @@ _filelist_entry_populate(const iso9660_dirent_t *dirent, iso9660_entry_type_t ty
                 name_len -= 2;
 
                 /* Empty extension */
-                if (name_len > 0 && dirent->name[name_len - 1] == '.')
+                if ((name_len > 0) && dirent->name[name_len - 1] == '.') {
                         name_len--;
+                }
         }
 
         (void)memcpy(filelist_entry->name, dirent->name, name_len);

--- a/libyaul/math/fix16_mat3.h
+++ b/libyaul/math/fix16_mat3.h
@@ -25,7 +25,7 @@ typedef union fix16_mat3 {
         fix16_t arr[9];
         fix16_t frow[3][3];
         fix16_vec3_t row[3];
-} __aligned(64) fix16_mat3_t;
+} __aligned(4) fix16_mat3_t;
 
 extern void fix16_mat3_dup(const fix16_mat3_t *, fix16_mat3_t *);
 extern void fix16_mat3_identity(fix16_mat3_t *);

--- a/libyaul/math/fix16_mat3.h
+++ b/libyaul/math/fix16_mat3.h
@@ -25,7 +25,7 @@ typedef union fix16_mat3 {
         fix16_t arr[9];
         fix16_t frow[3][3];
         fix16_vec3_t row[3];
-} __aligned(4) fix16_mat3_t;
+} __aligned(64) fix16_mat3_t;
 
 extern void fix16_mat3_dup(const fix16_mat3_t *, fix16_mat3_t *);
 extern void fix16_mat3_identity(fix16_mat3_t *);

--- a/libyaul/scu/bus/a/cs2/cd-block/cd-block.h
+++ b/libyaul/scu/bus/a/cs2/cd-block/cd-block.h
@@ -36,8 +36,9 @@ extern int cd_block_security_bypass();
  * @param offset        Offset from current FAD.
  * @param buffer_number Number of buffer to start reading.
  * @param output_buffer Buffer where data will be recorded.
+ * @param buffer_length Size of the buffer where data will be recorded.
  */
-extern int cd_block_transfer_data(uint16_t offset, uint16_t buffer_number, uint8_t *output_buffer);
+extern int cd_block_transfer_data(uint16_t offset, uint16_t buffer_number, uint8_t *output_buffer, uint32_t buffer_length);
 
 /**
  * Read a sector to a memory location. This function initialize and spins the

--- a/libyaul/scu/bus/a/cs2/cd-block/cd-block_init.c
+++ b/libyaul/scu/bus/a/cs2/cd-block/cd-block_init.c
@@ -186,8 +186,9 @@ cd_block_transfer_data(uint16_t offset, uint16_t buffer_number, uint8_t *output_
         read_buffer = (uint16_t *)output_buffer;
 
         uint32_t bytes_to_read = ISO9660_SECTOR_SIZE;
-        if (bytes_to_read > buffer_length)
+        if (bytes_to_read > buffer_length) {
                 bytes_to_read = buffer_length;
+        }
 
         uint32_t read_bytes = 0;
         for (uint32_t i = 0; i < bytes_to_read; i += 2) {
@@ -196,9 +197,10 @@ cd_block_transfer_data(uint16_t offset, uint16_t buffer_number, uint8_t *output_
                 read_bytes += 2;
         }
 
-        // If odd number of bytes, read the last one separated
+        /* If odd number of bytes, read the last one separated */
         if (read_bytes < buffer_length) {
-                uint16_t tmp = MEMORY_READ(16, CD_BLOCK(DTR));
+                const uint16_t tmp = MEMORY_READ(16, CD_BLOCK(DTR));
+
                 output_buffer[buffer_length - 1] = tmp >> 8;
         }
 


### PR DESCRIPTION
Fixes dirent->name access on iso9660.c
Change fix16_mat3_t alignment to 4 bytes
Allow buffers with any sizes to be used on cd_block_transfer_data