### PR TITLE
Update Arch packages in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,8 @@ repository, or build the [packages][6] yourself.
 
        pacman -S \
          yaul-tool-chain-git \
-         yaul-git \
+         yaul \
          yaul-emulator-mednafen \
-         yaul-emulator-kronos \
          yaul-examples-git
 
 4. Once all the packages have been installed, close the existing shell and start


### PR DESCRIPTION
The yaul package is now used instead of yaul-git, and the yaul-emulator-kronos package is no longer available.