### PR TITLE
Minor cdblock changes

### DIFF
--- a/libyaul/scu/bus/a/cs2/cd-block/cd-block.h
+++ b/libyaul/scu/bus/a/cs2/cd-block/cd-block.h
@@ -26,6 +26,11 @@ __BEGIN_DECLS
 extern int cd_block_init(void);
 
 /**
+ * Return if the cd block is busy for commands (HIRQ & CMOK) == false
+ */
+extern int cd_block_busy(void);
+
+/**
  * Bypass copy protection (by using JHL and CyberWarriorX exploit).
  */
 extern int cd_block_security_bypass(void);

--- a/libyaul/scu/bus/a/cs2/cd-block/cd-block.h
+++ b/libyaul/scu/bus/a/cs2/cd-block/cd-block.h
@@ -9,6 +9,7 @@
 #ifndef _YAUL_CD_BLOCK_H_
 #define _YAUL_CD_BLOCK_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <cd-block/cmd.h>
@@ -28,7 +29,7 @@ extern int cd_block_init(void);
 /**
  * Return if the cd block is busy for commands (HIRQ & CMOK) == false
  */
-extern int cd_block_busy(void);
+extern bool cd_block_busy(void);
 
 /**
  * Bypass copy protection (by using JHL and CyberWarriorX exploit).

--- a/libyaul/scu/bus/a/cs2/cd-block/cd-block_cmds.c
+++ b/libyaul/scu/bus/a/cs2/cd-block/cd-block_cmds.c
@@ -174,7 +174,7 @@ cd_block_cmd_cd_system_init(int16_t standby)
         regs.cr1 = 0x0400;
         regs.cr2 = standby;
         regs.cr3 = 0x0000;
-        regs.cr4 = 0x040F;
+        regs.cr4 = 0x0001;
 
         return cd_block_cmd_execute(&regs, &status);
 }

--- a/libyaul/scu/bus/a/cs2/cd-block/cd-block_execute.c
+++ b/libyaul/scu/bus/a/cs2/cd-block/cd-block_execute.c
@@ -14,7 +14,7 @@
 #include "cd-block-internal.h"
 #include "cd-block/cmd.h"
 
-int
+bool
 cd_block_busy(void) {
         /* Is the CD-block busy? */
         return ((MEMORY_READ(16, CD_BLOCK(HIRQ)) & CMOK) == 0x0000);


### PR DESCRIPTION
Expose cd_block_busy, use status flags instead of constants and use ECC frequency = 0 (max of 1 time in real time) and retry to 1 time.

Ideally we should expose some fields for ECC and Retry initialization in libyaul so user can select those