### PR TITLE
Fix 4bpp tiled tga bugs

### DIFF
--- a/libtga/tga.c
+++ b/libtga/tga.c
@@ -532,7 +532,7 @@ _cmap_image_tile_draw(uint8_t *dst, uint16_t tx, uint16_t ty, const tga_t *tga)
                         uint32_t x_offset;
                         x_offset = (tile_width * tx) + x;
                         uint32_t y_offset;
-                        y_offset = ((tile_width * ty) + y) * tga->tga_width;
+                        y_offset = ((tile_height * ty) + y) * tga->tga_width;
                         
                         if (tile_width == 4)
                                 y_offset /= 2;

--- a/libtga/tga.c
+++ b/libtga/tga.c
@@ -533,10 +533,11 @@ _cmap_image_tile_draw(uint8_t *dst, uint16_t tx, uint16_t ty, const tga_t *tga)
                         x_offset = (tile_width * tx) + x;
                         uint32_t y_offset;
                         y_offset = ((tile_height * ty) + y) * tga->tga_width;
-                        
-                        if (tile_width == 4)
+
+                        if (tile_width == 4) {
                                 y_offset /= 2;
-                        
+                        }
+
                         uint32_t offset;
                         offset = x_offset + y_offset;
 

--- a/libtga/tga.c
+++ b/libtga/tga.c
@@ -533,6 +533,10 @@ _cmap_image_tile_draw(uint8_t *dst, uint16_t tx, uint16_t ty, const tga_t *tga)
                         x_offset = (tile_width * tx) + x;
                         uint32_t y_offset;
                         y_offset = ((tile_width * ty) + y) * tga->tga_width;
+                        
+                        if (tile_width == 4)
+                                y_offset /= 2;
+                        
                         uint32_t offset;
                         offset = x_offset + y_offset;
 


### PR DESCRIPTION
When a 4bpp tga is decoded using the `tga_image_decode_tiled` function, odd rows are skipped. This addresses that. This is a quick fix; there definitely are more performant ways to do this, such as a bitshift, but for clarity reasons I opted not to do that.